### PR TITLE
Fixed issues with variable names.

### DIFF
--- a/src/Sheets/Sheet.cpp
+++ b/src/Sheets/Sheet.cpp
@@ -21,7 +21,7 @@ Sheet::Sheet() {
 
 bool Sheet::BannedVariableNameCheck(std::wstring name) {
     std::transform(name.begin(), name.end(), name.begin(), ::towlower);
-    return functionNames.count(name) > 0;
+    return functionNames.count(name) > 0 || name.empty();
 }
 
 std::vector<std::pair<size_t, size_t>> Sheet::FunctionNameLocations(std::wstring line) {
@@ -33,8 +33,10 @@ std::vector<std::pair<size_t, size_t>> Sheet::FunctionNameLocations(std::wstring
     for(auto const& x : functionNames) {
         size_t pos = line.find(x, equal);
         while(pos != std::wstring::npos) {
-            std::pair<size_t, size_t> pair(pos, x.length());
-            positions.push_back(pair);
+            if(pos == 0 || !std::iswalpha(line.at(pos - 1))) {
+                std::pair<size_t, size_t> pair(pos, x.length());
+                positions.push_back(pair);
+            }
             pos = line.find(x, pos + 1);
         }
     }

--- a/src/SparkCalc.cpp
+++ b/src/SparkCalc.cpp
@@ -85,7 +85,7 @@ void SparkCalc::OnAbout(wxCommandEvent& WXUNUSED(event))
                  (
                     "Welcome to Spark Calculator!\n"
                     "\n"
-                    "This is version 0.0.2a "
+                    "This is version 0.0.2b "
                     "running under %s.",
                     wxGetOsDescription()
                  ),


### PR DESCRIPTION
Previously there were issues with creating variables with empty names. If you inserted an '=' sign onto a line and hit enter, the program would enter an infinite loop due to how variable replacement works. Additionally, variable names that contain function names (ex: The function: 'cos' and the variable: 'cost') would incorrectly color in the function name, even though it was not intended to be a function. These two issues have been addressed, and the version number has been bumped to 0.0.2b